### PR TITLE
Tarea #3191 - agregar fechas dinamicas al valor filtros

### DIFF
--- a/Controller/EditReport.php
+++ b/Controller/EditReport.php
@@ -23,7 +23,7 @@ use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\EditController;
 use FacturaScripts\Core\Tools;
-use FacturaScripts\Plugins\Informes\Model\PresetFilterValues;
+use FacturaScripts\Plugins\Informes\Lib\PresetFilterValues;
 use FacturaScripts\Plugins\Informes\Model\Report;
 
 /**

--- a/Controller/EditReport.php
+++ b/Controller/EditReport.php
@@ -23,6 +23,7 @@ use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Lib\ExtendedController\BaseView;
 use FacturaScripts\Core\Lib\ExtendedController\EditController;
 use FacturaScripts\Core\Tools;
+use FacturaScripts\Plugins\Informes\Model\PresetFilterValues;
 use FacturaScripts\Plugins\Informes\Model\Report;
 
 /**
@@ -153,6 +154,17 @@ class EditReport extends EditController
                 $columnTable = $this->views[$viewName]->columnForField('table_column');
                 if ($columnTable && $columnTable->widget->getType() === 'select') {
                     $columnTable->widget->setValuesFromArray($columns);
+                }
+
+                /** AGREAGMOS OPCIONES AL DATALIST DE VALORES */
+                $column = $this->views['EditReportFilter']->columnForName('value');
+                if($column && $column->widget->getType() === 'datalist') {
+                    $customValues = [];
+                    $presetFilterValues = new PresetFilterValues();
+                    foreach ($presetFilterValues->all() as $key => $valor){
+                        $customValues[] = ['value' => $key, 'title' => $valor];
+                    }
+                    $column->widget->setValuesFromArray($customValues);
                 }
 
                 $where = [new DataBaseWhere('id_report', $id)];

--- a/Lib/PresetFilterValues.php
+++ b/Lib/PresetFilterValues.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace FacturaScripts\Plugins\Informes\Model;
+namespace FacturaScripts\Plugins\Informes\Lib;
 
 use FacturaScripts\Dinamic\Model\Base\ModelCore;
 

--- a/Model/PresetFilterValues.php
+++ b/Model/PresetFilterValues.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace FacturaScripts\Plugins\Informes\Model;
+
+use FacturaScripts\Dinamic\Model\Base\ModelCore;
+
+class PresetFilterValues
+{
+    private $presets;
+
+    public function __construct()
+    {
+        $this->presets = [
+            'Fecha actual' => $this->date('now'),
+            'Fecha de ayer' => $this->date('-1 day'),
+            'Fecha de hace 7 días' => $this->date('-7 day'),
+            'Fecha de hace 15 días' => $this->date('-15 day'),
+            'Fecha de hace 1 mes' => $this->date('-1 month'),
+            'Fecha de hace 3 meses' => $this->date('-3 months'),
+            'Fecha de hace 6 meses' => $this->date('-6 months'),
+            'Fecha de hace 1 año' => $this->date('-1 year'),
+            'Fecha de hace 2 años' => $this->date('-2 years'),
+            'Fecha y hora actual' => $this->dateTime('now'),
+            'Fecha y hora de ayer' => $this->dateTime('-1 day'),
+            'Fecha y hora de hace 7 días' => $this->dateTime('-7 day'),
+            'Fecha y hora de hace 15 días' => $this->dateTime('-15 day'),
+            'Fecha y hora de hace 1 mes' => $this->dateTime('-1 month'),
+            'Fecha y hora de hace 3 meses' => $this->dateTime('-3 months'),
+            'Fecha y hora de hace 6 meses' => $this->dateTime('-6 months'),
+            'Fecha y hora de hace 1 año' => $this->dateTime('-1 year'),
+            'Fecha y hora de hace 2 años' => $this->dateTime('-2 years'),
+            'Hora actual' => $this->dateTime('now'),
+            'Hace una hora' => $this->dateTime('-1 hour'),
+        ];
+    }
+
+    public function all()
+    {
+        return array_keys($this->presets);
+    }
+
+    public function getValue(string $value)
+    {
+        return $this->presets[$value];
+    }
+
+    protected function date(string $time)
+    {
+        return date(ModelCore::DATE_STYLE, strtotime($time));
+    }
+
+    protected function dateTime(string $time)
+    {
+        return date(ModelCore::DATETIME_STYLE, strtotime($time));
+    }
+}

--- a/Model/Report.php
+++ b/Model/Report.php
@@ -23,6 +23,7 @@ use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 use FacturaScripts\Core\Model\Base;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Where;
+use FacturaScripts\Plugins\Informes\Lib\PresetFilterValues;
 
 /**
  * Description of Report

--- a/Model/Report.php
+++ b/Model/Report.php
@@ -103,6 +103,13 @@ class Report extends Base\ModelClass
                 continue;
             }
 
+            // Parseamos la fecha, si se trata de un valor de fecha predefinido.
+            $filter->value = trim($filter->value);
+            $presetFilterValues = new PresetFilterValues();
+            if(in_array($filter->value, $presetFilterValues->all())){
+                $filter->value = $presetFilterValues->getValue($filter->value);
+            }
+
             $where[] = Where::column($filter->table_column, $filter->value, $filter->operator);
         }
 

--- a/XMLView/EditReportFilter.xml
+++ b/XMLView/EditReportFilter.xml
@@ -44,7 +44,7 @@
                 </widget>
             </column>
             <column name="value" order="120">
-                <widget type="text" fieldname="value"/>
+                <widget type="datalist" fieldname="value" required="true" />
             </column>
         </group>
     </columns>


### PR DESCRIPTION
En ocasiones queremos hacer filtros dinámicos en los informes gráficos. Por ejemplo: obtener los datos de los últimos 30 días. Pero ahora mismo es imposible, ya que solamente podemos poner valore fijos.

He modificado el widget de valor a un datalist y he agregado funcionalidad para poder elegir entre estas fechas dinamicas:

    Fecha actual.
    Fecha de ayer.
    Fecha de hace 7 días.
    Fecha de hace 15 días.
    Fecha de hace 1 mes.
    Fecha de hace 3 meses.
    Fecha de hace 6 meses.
    Fecha de hace 1 año.
    Fecha de hace 2 años.
    Fecha y hora actual.
    Fecha y hora de ayer.
    Fecha y hora de hace 7 días.
    Fecha y hora de hace 15 días.
    Fecha y hora de hace 1 mes.
    Fecha y hora de hace 3 meses.
    Fecha y hora de hace 6 meses.
    Fecha y hora de hace 1 año.
    Fecha y hora de hace 2 años.
    Hora actual.
    Hace una hora.
