### PR TITLE
Evitar carga automática

### DIFF
--- a/View/ReportResult.html.twig
+++ b/View/ReportResult.html.twig
@@ -731,7 +731,11 @@
                 }
             });
 
-            initPage();
+            // Only lunch the load data if there are less than 2 companies
+            const select = document.getElementById('selectExercise');
+            if (select && select.getElementsByTagName('optgroup').length < 2) {
+                initPage();
+            }
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Cuando la instalación tiene multiples empresas no se lanza la carga inicial de los datos de resumen.