### PR TITLE
fix: showing global product stock on ReportProducto

### DIFF
--- a/Model/Join/AlbaranClienteProducto.php
+++ b/Model/Join/AlbaranClienteProducto.php
@@ -35,6 +35,8 @@ class AlbaranClienteProducto extends FacturaClienteProducto
         return static::MAIN_TABLE
             . ' LEFT JOIN variantes ON ' . static::MAIN_TABLE . '.referencia = variantes.referencia'
             . ' LEFT JOIN productos ON variantes.idproducto = productos.idproducto'
-            . ' LEFT JOIN albaranescli ON albaranescli.idalbaran = lineasalbaranescli.idalbaran';
+            . ' LEFT JOIN albaranescli ON albaranescli.idalbaran = lineasalbaranescli.idalbaran'
+            . ' LEFT JOIN stocks ON stocks.referencia = ' . static::MAIN_TABLE . '.referencia'
+            . ' AND stocks.codalmacen = ' . static::DOC_TABLE . '.codalmacen';
     }
 }

--- a/Model/Join/AlbaranProveedorProducto.php
+++ b/Model/Join/AlbaranProveedorProducto.php
@@ -35,6 +35,8 @@ class AlbaranProveedorProducto extends FacturaProveedorProducto
         return static::MAIN_TABLE
             . ' LEFT JOIN variantes ON ' . static::MAIN_TABLE . '.referencia = variantes.referencia'
             . ' LEFT JOIN productos ON variantes.idproducto = productos.idproducto'
-            . ' LEFT JOIN albaranesprov ON albaranesprov.idalbaran = lineasalbaranesprov.idalbaran';
+            . ' LEFT JOIN albaranesprov ON albaranesprov.idalbaran = lineasalbaranesprov.idalbaran'
+            . ' LEFT JOIN stocks ON stocks.referencia = ' . static::MAIN_TABLE . '.referencia'
+            . ' AND stocks.codalmacen = ' . static::DOC_TABLE . '.codalmacen';
     }
 }

--- a/Model/Join/FacturaClienteProducto.php
+++ b/Model/Join/FacturaClienteProducto.php
@@ -50,7 +50,7 @@ class FacturaClienteProducto extends JoinModel
             'idproducto' => static::MAIN_TABLE . '.idproducto',
             'precio' => 'variantes.precio',
             'referencia' => static::MAIN_TABLE . '.referencia',
-            'stockfis' => 'variantes.stockfis'
+            'stockfis' => 'stocks.cantidad'
         ];
     }
 
@@ -58,7 +58,7 @@ class FacturaClienteProducto extends JoinModel
     {
         return static::DOC_TABLE . '.codalmacen, ' . static::MAIN_TABLE . '.idproducto, '
             . static::MAIN_TABLE . '.referencia, productos.codfabricante, productos.codfamilia, variantes.coste, '
-            . 'productos.descripcion, variantes.precio, variantes.stockfis';
+            . 'productos.descripcion, variantes.precio, stocks.cantidad';
     }
 
     protected function getSQLFrom(): string
@@ -66,11 +66,13 @@ class FacturaClienteProducto extends JoinModel
         return static::MAIN_TABLE
             . ' LEFT JOIN variantes ON ' . static::MAIN_TABLE . '.referencia = variantes.referencia'
             . ' LEFT JOIN productos ON variantes.idproducto = productos.idproducto'
-            . ' LEFT JOIN facturascli ON facturascli.idfactura = lineasfacturascli.idfactura';
+            . ' LEFT JOIN facturascli ON facturascli.idfactura = lineasfacturascli.idfactura'
+            . ' LEFT JOIN stocks ON stocks.referencia = ' . static::MAIN_TABLE . '.referencia'
+            . ' AND stocks.codalmacen = ' . static::DOC_TABLE . '.codalmacen';
     }
 
     protected function getTables(): array
     {
-        return [static::MAIN_TABLE, 'productos', 'variantes'];
+        return [static::MAIN_TABLE, 'productos', 'variantes', 'stocks'];
     }
 }

--- a/Model/Join/FacturaProveedorProducto.php
+++ b/Model/Join/FacturaProveedorProducto.php
@@ -49,7 +49,7 @@ class FacturaProveedorProducto extends JoinModel
             'idproducto' => static::MAIN_TABLE . '.idproducto',
             'precio' => 'variantes.precio',
             'referencia' => static::MAIN_TABLE . '.referencia',
-            'stockfis' => 'variantes.stockfis'
+            'stockfis' => 'stocks.cantidad'
         ];
     }
 
@@ -57,7 +57,7 @@ class FacturaProveedorProducto extends JoinModel
     {
         return static::DOC_TABLE . '.codalmacen, ' . static::MAIN_TABLE . '.idproducto, '
             . static::MAIN_TABLE . '.referencia, productos.codfabricante, productos.codfamilia, variantes.coste, '
-            . 'productos.descripcion, variantes.precio, variantes.stockfis';
+            . 'productos.descripcion, variantes.precio, stocks.cantidad';
     }
 
     protected function getSQLFrom(): string
@@ -65,11 +65,13 @@ class FacturaProveedorProducto extends JoinModel
         return static::MAIN_TABLE
             . ' LEFT JOIN variantes ON ' . static::MAIN_TABLE . '.referencia = variantes.referencia'
             . ' LEFT JOIN productos ON variantes.idproducto = productos.idproducto'
-            . ' LEFT JOIN facturasprov ON facturasprov.idfactura = lineasfacturasprov.idfactura';
+            . ' LEFT JOIN facturasprov ON facturasprov.idfactura = lineasfacturasprov.idfactura'
+            . ' LEFT JOIN stocks ON stocks.referencia = ' . static::MAIN_TABLE . '.referencia'
+            . ' AND stocks.codalmacen = ' . static::DOC_TABLE . '.codalmacen';
     }
 
     protected function getTables(): array
     {
-        return [static::MAIN_TABLE, 'productos', 'variantes'];
+        return [static::MAIN_TABLE, 'productos', 'variantes', 'stocks'];
     }
 }


### PR DESCRIPTION
Solución para el bug reportado por esta issue: https://facturascripts.com/issues/114-867-630

Básicamente en el ReportProduct donde reporta el conjunto de las lineas de documentos, cuando muestra el stock para cada almacen, el stock vendido se muestra correctamente (cada almacen tiene su propio stock) pero cuando se muestra el stock restante solo se muestra el stock global (el total de stock) y no el stock de cada almacen como sería lógico.